### PR TITLE
Adding reccomended extensions

### DIFF
--- a/.vscode/extensions.json
+++ b/.vscode/extensions.json
@@ -4,6 +4,7 @@
     "recommendations": [
       "redhat.java",
       "redhat.vscode-quarkus",
-      "ms-vscode.vscode-github-pullrequest",
+      "github.vscode-pull-request-github",
+      "genuitecllc.codetogether"
     ]
 }

--- a/.vscode/extensions.json
+++ b/.vscode/extensions.json
@@ -2,6 +2,7 @@
     // See https://go.microsoft.com/fwlink/?LinkId=827846
     // for the documentation about the extensions.json format
     "recommendations": [
+      "redhat.java",
       "redhat.vscode-quarkus",
       "ms-vscode.vscode-github-pullrequest",
     ]


### PR DESCRIPTION
Actually not sure if we need to set it explicitly since java seems to be a req for quarkus extention - https://marketplace.visualstudio.com/items?itemName=redhat.vscode-quarkus 

The recommended list looks the following way now:

![image](https://user-images.githubusercontent.com/1461122/179990922-077b5937-c719-4e15-91f9-51451223f3cf.png)
