### PR TITLE
hot-fix: removing generated name due to deffect in the product

### DIFF
--- a/devfile.yaml
+++ b/devfile.yaml
@@ -1,6 +1,6 @@
 schemaVersion: 2.1.0
 metadata:
-  generateName: quarkus-api-example
+  name: quarkus-api-example
 attributes:
   controller.devfile.io/storage-type: ephemeral
 components:


### PR DESCRIPTION
see `generateName` attribute is not processed correctly and workspace is failing to start - https://github.com/eclipse/che/issues/21810