### PR TITLE
Update readme and add build image command

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,6 +15,21 @@ NOTE: Perfoming a native Quarkus build with the `packagenative` command fails on
 | `GET`  | `/food/restaurant/{restaurantName}` | Lists all Food resources with the specified restaurantName |
 | `POST` | `/food`                             | Creates a Food resource                                    |
 
+## Development with Eclipse Che
+
+This project provides a [devfile.yaml](https://github.com/che-incubator/quarkus-api-example/blob/main/devfile.yaml) file that defines the containers required for development, as well as a list of development commands.
+
+To run these commands from VS Code, open the command palette and navigate to `Tasks: Run Task` > `che`.
+
+| Task                                          | Description                                                                                                     |
+|-----------------------------------------------|-----------------------------------------------------------------------------------------------------------------|
+| `Package`                                     | Runs `mvn package`.                                                                                             |
+| `Run Tests`                                   | Runs `mvn test`.                                                                                                |
+| `Package Native`                              | Runs a Quarkus native build.                                                                                    |
+| `Build Image`                                 | Builds a container image for the Quarkus application running in JVM mode. `Package` task must be run before this task. |
+| `Start Development mode (Hot reload + debug)` | Runs the Quarkus application in development mode.                                                               |
+| `Start Native`                                | Runs the Quarkus native binary. `Package Native` task must be run before this task.                             |
+
 ## Local development
 ### Create PostgresSQL container
 ```

--- a/devfile.yaml
+++ b/devfile.yaml
@@ -61,7 +61,7 @@ commands:
         isDefault: true
   - id: runtests
     exec:
-      label: "Run tests"
+      label: "Run Tests"
       component: tools
       workingDir: ${PROJECTS_ROOT}/quarkus-api-example
       commandLine: "./mvnw test"
@@ -92,6 +92,14 @@ commands:
       commandLine: "./quarkus-api-example-1.0.0-SNAPSHOT-runner"
       group:
         kind: run
+  - id: buildimage
+    exec:
+      label: "Build Image"
+      component: tools
+      workingDir: ${PROJECT_SOURCE}
+      commandLine: "podman build -f src/main/docker/Dockerfile.jvm -t quay.io/che-incubator/quarkus-api-example ."
+      group:
+        kind: build
   - id: tag
     exec:
       label: "Tag Image"


### PR DESCRIPTION
Signed-off-by: dakwon <dakwon@che>

Adds more information to the readme about the development tasks defined in the devfile.
Adds a command to build an image using podman and the dockerfile located in `src/main/docker/Dockerfile.jvm`.

Readme preview:
<img width="912" alt="image" src="https://user-images.githubusercontent.com/83611742/208960704-fe647c71-473d-42e3-806d-3bf46ed6ce89.png">

