### PR TITLE
Change protocol to https

### DIFF
--- a/devfile.yaml
+++ b/devfile.yaml
@@ -17,7 +17,7 @@ components:
           targetPort: 5005
         - exposure: public
           name: list-all-food
-          protocol: http
+          protocol: https
           targetPort: 8080
           path: /food
       volumeMounts:


### PR DESCRIPTION
This PR updates the `list-all-food` endpoints protocol from http to https.

To test, run the devfile tasks `Package` and `Start Development mode` and click on "Open In New Tab":
![image](https://github.com/user-attachments/assets/6e4334e3-49da-4e4f-a01c-9a195f0b676e)

and verify that https is being used:
![image](https://github.com/user-attachments/assets/02089466-16cd-4e06-8b25-197d74c96bc6)

