### PR TITLE
Remove poststart event from devfile.yaml

### DIFF
--- a/devfile.yaml
+++ b/devfile.yaml
@@ -103,6 +103,3 @@ commands:
       commandLine: "oc new-app -e POSTGRESQL_USER=user -e POSTGRESQL_PASSWORD=password -e POSTGRESQL_DATABASE=food_db postgresql:10-el7 -n demo"
       group:
         kind: test
-events:
-  postStart:
-    - package


### PR DESCRIPTION
Avoid error "Error creating DevWorkspace deployment: Detected unrecoverable event FailedPostStartHook: PostStartHook failed." when start workspace in DevSpaces 3.17 / Eclipse Che 7.96